### PR TITLE
Specify chaincode builder version - Fixes chaincode instantiation error 

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -100,6 +100,9 @@ name: "{{peer2_user}}", password: "{{peer2_password}}",
 leader: "{{peer1_user}}"
 }
 
+peer_chaincode_builder : {
+  image: "hyperledger/fabric-ccenv", tag: "1.4"
+}
 ######################################### CLI #############################################
 cli: { switch: "on", image: "hyperledger/fabric-tools", tag: "1.4"}
 ######################################### DBs #############################################
@@ -173,3 +176,4 @@ services:
   - "{{swarm_visualizer}}"
   - "{{portainer}}"
   - "{{portainer_agent}}"
+  - "{{peer_chaincode_builder}}"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -101,7 +101,7 @@ leader: "{{peer1_user}}"
 }
 
 peer_chaincode_builder : {
-  image: "hyperledger/fabric-ccenv", tag: "1.4"
+  "name":"hyperledger_fabric-ccenv", image: "hyperledger/fabric-ccenv", tag: "1.4"
 }
 ######################################### CLI #############################################
 cli: { switch: "on", image: "hyperledger/fabric-tools", tag: "1.4"}

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -100,9 +100,6 @@ name: "{{peer2_user}}", password: "{{peer2_password}}",
 leader: "{{peer1_user}}"
 }
 
-peer_chaincode_builder : {
-  "name":"hyperledger_fabric-ccenv", image: "hyperledger/fabric-ccenv", tag: "1.4"
-}
 ######################################### CLI #############################################
 cli: { switch: "on", image: "hyperledger/fabric-tools", tag: "1.4"}
 ######################################### DBs #############################################
@@ -176,4 +173,3 @@ services:
   - "{{swarm_visualizer}}"
   - "{{portainer}}"
   - "{{portainer_agent}}"
-  - "{{peer_chaincode_builder}}"

--- a/roles/hlf/peer/tasks/main.yml
+++ b/roles/hlf/peer/tasks/main.yml
@@ -100,6 +100,7 @@
       - "CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS={{couchdb.name}}_{{item.name}}:5984"
       - "CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME={{couchdb.name}}"
       - "CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD={{couchdb.password}}"
+      - "CORE_CHAINCODE_BUILDER: hyperledger/fabric-ccenv:{{item.tag}}"
     working_dir: "{{item.path}}"
     placement:      
       constraints:

--- a/roles/hlf/peer/tasks/main.yml
+++ b/roles/hlf/peer/tasks/main.yml
@@ -100,7 +100,7 @@
       - "CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS={{couchdb.name}}_{{item.name}}:5984"
       - "CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME={{couchdb.name}}"
       - "CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD={{couchdb.password}}"
-      - "CORE_CHAINCODE_BUILDER: hyperledger/fabric-ccenv:{{item.tag}}"
+      - "CORE_CHAINCODE_BUILDER=hyperledger/fabric-ccenv:{{item.tag}}"
     working_dir: "{{item.path}}"
     placement:      
       constraints:


### PR DESCRIPTION
- Specify **specifc chaincode builder version** through environmental variable "**CORE_CHAINCODE_BUILDER**" to peer service. 

- **Reference :** https://stackoverflow.com/questions/62860545/instantiation-of-chaincode-using-fabric-node-sdk-gives-api-error-404-manifest

- **Fixes chaincode instantiation error :**  "Error: could not assemble transaction, err proposal response was not successful, error code 500, msg error starting container: error starting container: Failed to generate platform-specific docker build: **Failed to pull hyperledger/fabric-ccenv:latest: API error (404): manifest for hyperledger/fabric-ccenv:latest not found: manifest unknown: manifest unknown**"

![Screenshot from 2020-07-20 16-58-57](https://user-images.githubusercontent.com/30879156/87959409-219b3d00-cab3-11ea-9045-fd7c901e28ea.png)

    
