### PR TITLE
- Fixes amazon vms docker swarm containers not reachable issue

### DIFF
--- a/roles/swarm/tasks/main.yml
+++ b/roles/swarm/tasks/main.yml
@@ -42,7 +42,7 @@
   docker_swarm:
     state: join
     join_token: "{{ hostvars[groups.swarm_manager_prime[0]]['result'].swarm_facts.JoinTokens.Manager }}"
-    advertise_addr: "eth0:4567"
+    advertise_addr: "{{ ansible_host }}:4567"
     remote_addrs: ["{{ hostvars[groups.swarm_manager_prime[0]]['ansible_host'] }}:2377" ]
   retries: 3
   delay: 15
@@ -55,7 +55,7 @@
   docker_swarm:
     state: join
     join_token: "{{ hostvars[groups.swarm_manager_prime[0]]['result'].swarm_facts.JoinTokens.Worker }}"
-    advertise_addr: "eth0:4567"
+    advertise_addr: "{{ ansible_host }}:4567"
     remote_addrs: "{{ hostvars[groups.swarm_manager_prime[0]]['ansible_host'] }}"
   retries: 3
   delay: 20


### PR DESCRIPTION
**Fixes amazon vms docker swarm containers not reachable issue**

- specified advertise_swarm addr to use the public ip  from inventory_host 

**Reference :** https://github.com/docker/classicswarm/issues/2687#issuecomment-324610015