### PR TITLE
Fixes - issue#32 - Aws Issue - TASK [hlf/peer : Copy TLS certs] - Certificates not found #32

### DIFF
--- a/roles/hlf/peer/tasks/main.yml
+++ b/roles/hlf/peer/tasks/main.yml
@@ -30,6 +30,7 @@
 
 # Copy tls certs
 - name: Copy TLS certs
+  become: yes
   copy:
     src: "/root/hlft-store/{{tlsca.name}}/{{item.0.name}}/tls-msp/{{item.1}}"
     dest: "/root/hlft-store/{{orgca.name}}/{{item.0.name}}/msp/tls/{{item.2}}"


### PR DESCRIPTION
**Fixes - issue#32 - Aws Issue - TASK [hlf/peer : Copy TLS certs] - Certificates not found #32**

**Reason:**  Permission problems

**Solution:**  Execute task with root priveleges