### PR TITLE
Fixes #40 - Create Playbook to deploy the sample bank app as a docker service for the articonf reachout demo

### DIFF
--- a/105.deploy_bank_app.yml
+++ b/105.deploy_bank_app.yml
@@ -1,0 +1,8 @@
+---
+# ansible-playbook -v 105.deploy_bank_app.yml --flush-cache -u root
+
+- name: Deploy Sample Bank App service
+  hosts: swarm_manager_prime
+  gather_facts: yes
+  roles:
+    - bank_app

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -164,6 +164,15 @@ portainer_agent : {
   switch: "on",
 }
 
+bank_app : {
+  git_repository : "https://github.com/bityoga/articonf-bank-app.git",
+  name : 'bank-service',
+  replicas: -1,
+  port : 3000,
+  switch: "on",
+}
+
+
 ###########################################################################################
 #                                                                                         #
 #                                                                                         #

--- a/roles/bank_app/tasks/main.yml
+++ b/roles/bank_app/tasks/main.yml
@@ -1,0 +1,66 @@
+# ---
+# Stop all Bank App services
+- name: Stop Bank App  Service - {{ item.name }}
+  become: yes
+  docker_swarm_service:
+    name: "{{item.name}}"
+    state: absent
+    networks:
+      - "{{swarm_network}}"
+  loop:
+    - "{{bank_app}}"
+  when: bank_app.switch == "on" and inventory_hostname in groups.swarm_manager_prime
+
+  # Clean  bank-app files folders , if they exists
+- name: Clean  bank-app files folders , if they exists
+  become: yes
+  file:
+    path: "/root/articonf-bank-app/"
+    state: absent
+  when: bank_app.switch == "on"
+
+  # git clone  bank-app files
+- name: Git clone  bank-app files
+  become: yes
+  shell: git clone {{bank_app.git_repository}} /root/articonf-bank-app
+
+  # Copy orderer tls certificate to bank app folder
+- name: Copy orderer certificate to bank app folder
+  become: yes
+  shell: cp /root/hlft-store/{{orgca.name}}/{{orderer.name}}/msp/tls/ca.crt /root/articonf-bank-app/fabric_node_sdk_helper/hlft-store/{{orderer.name}}/tls-msp/tlscacerts/ca.crt
+
+  # Copy peer2 tls certificate to bank app folder
+- name: Copy peer2 certificate to bank app folder
+  become: yes
+  shell: cp /root/hlft-store/{{orgca.name}}/{{peer2.name}}/msp/tls/ca.crt /root/articonf-bank-app/fabric_node_sdk_helper/hlft-store/{{peer2.name}}/tls-msp/tlscacerts/ca.crt
+
+# Template copy bank app network_config.json file
+- name: Template copy bank app network_config.json file
+  become: yes
+  template:
+    src: "bank_app_network_profile.json"
+    dest: "/root/articonf-bank-app/fabric_node_sdk_helper/network_profile.json"
+    mode: "0750"
+    force: yes
+  when: bank_app.switch == "on"
+
+# Template copy bank app Dockerfile
+- name: Template copy bank app Dockerfile
+  become: yes
+  template:
+    src: "bank_app_Dockerfile"
+    dest: "/root/articonf-bank-app/Dockerfile"
+    mode: "0750"
+    force: yes
+  when: bank_app.switch == "on"
+
+  # Build Docker Image
+- name: Build Docker Image for bank app
+  become: yes
+  shell: docker build --tag bank-app /root/articonf-bank-app/
+  ignore_errors: yes
+
+  # Run as docker service with replicas
+- name: Run as docker service with replicas
+  become: yes
+  shell: docker service create --name bank-service --replicas 1 -p 3000:3000 bank-app:latest

--- a/templates/bank_app_Dockerfile
+++ b/templates/bank_app_Dockerfile
@@ -1,0 +1,19 @@
+FROM node:11
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+EXPOSE {{bank_app.port}}
+CMD [ "node", "app.js" ]

--- a/templates/bank_app_network_profile.json
+++ b/templates/bank_app_network_profile.json
@@ -1,0 +1,84 @@
+{
+  "name": "{{org.name}}-{{org.unit}}",
+  "version": "1.0.0",
+  "client": {
+    "organization": "{{org.name}}",
+    "connection": {
+      "timeout": {
+        "peer": {
+          "endorser": "300"
+        }
+      }
+    }
+  },
+  "channels": {
+    "appchannel": {
+      "orderers": ["{{orderer.name}}"],
+      "peers": {
+        "{{peer2.name}}": {
+          "endorsingPeer": "true",
+          "chaincodeQuery": "true",
+          "ledgerQuery": "true",
+          "eventSource": "true",
+          "discover": "true"
+        },
+        "{{peer1.name}}": {
+          "endorsingPeer": "false",
+          "chaincodeQuery": "false",
+          "ledgerQuery": "true",
+          "eventSource": "false",
+          "discover": "true"
+        }
+      }
+    }
+  },
+  "organizations": {
+    "{{org.name}}": {
+      "mspid": "{{org.name}}MSP",
+      "peers": ["{{peer2.name}}", "{{peer1.name}}"],
+      "certificateAuthorities": ["{{orgca.name}}", "{{tlsca.name}}"]
+    }
+  },
+
+  "orderers": {
+    "{{orderer.name}}": {
+      "url": "grpcs://{{ ansible_default_ipv4.address }}:{{orderer.port}}",
+      "tlsCACerts": {
+        "path": "./hlft-store/{{orderer.name}}/tls-msp/tlscacerts/ca.crt"
+      },
+      "grpcOptions": {
+        "ssl-target-name-override": "{{orderer.name}}"
+      }
+    }
+  },
+
+  "peers": {
+    "{{peer2.name}}": {
+      "url": "grpcs://{{ ansible_default_ipv4.address }}:{{peer2.port}}",
+
+      "tlsCACerts": {
+        "path": "./hlft-store/{{peer2.name}}/tls-msp/tlscacerts/ca.crt"
+      },
+      "grpcOptions": {
+        "ssl-target-name-override": "{{peer2.name}}"
+      }
+    }
+  },
+  "certificateAuthorities": {
+    "{{orgca.name}}": {
+      "caName": "{{orgca.name}}",
+      "url": "https://{{ ansible_default_ipv4.address }}:{{orgca.port}}",
+      "httpOptions": {
+        "verify": false
+      }
+    },
+
+    "{{tlsca.name}}": {
+      "caName": "{{tlsca.name}}",
+      "url": "https://{{ ansible_default_ipv4.address }}:{{tlsca.port}}",
+      "httpOptions": {
+        "verify": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Fixes #40 - Create Playbook to deploy the sample bank app as a docker service for the articonf reachout demo**

- The app is developed and made open source in **github :** https://github.com/bityoga/articonf-bank-app
- a new playbook 05.deploy_bank_app.yml is added to deploy the app as a dervice 
- The playbook clones the github repository and runs the app as a docker service in port 3000

**Demo** 

![fabricbank](https://user-images.githubusercontent.com/30879156/95440372-2ad0d300-0959-11eb-9c9f-20d545451ca8.gif)
