### PR TITLE
Fix duplicate orderer type warning in group_vars/all.yml

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -84,7 +84,7 @@ orgca: { switch: "on", image: "hyperledger/fabric-ca", tag: "1.4", replicas: -1,
 ######################################### Orderer #############################################
 orderer: { switch: "on", image: "hyperledger/fabric-orderer", tag: "2.2", replicas: -1, port: 8053,
 caname: "{{orgca.name}}", anchorpeer: "{{peer1.name}}", anchorport: "{{peer1.port}}",
-path: "/root/{{orderer_user}}", type: "solo",
+path: "/root/{{orderer_user}}",
 name: "{{orderer_user}}", password: "{{orderer_password}}", type: "orderer"
 }
 


### PR DESCRIPTION
**Fix duplicate orderer type warning in group_vars/all.yml**

- removed "solo" orderer type for orderer variable in group_vars/all.yml