### PR TITLE
Fixes issue #51 "peer2_cli" service fails to start sometimes, as it starts before peer2 service is ready

### DIFF
--- a/roles/hlf/cli/ca/tasks/main.yaml
+++ b/roles/hlf/cli/ca/tasks/main.yaml
@@ -26,7 +26,7 @@
 - name: ENROLL Agents for Fabric Service - "{{ item.0.name }}_{{item.1.1.name}}_cli"
   become: yes
   docker_swarm_service:
-    restart_policy: "none"
+    restart_policy: "on-failure"
     name: "{{ item.0.name }}_{{item.1.1.name}}_cli"
     hostname: "{{ item.0.name }}_{{item.1.1.name}}_cli"
     networks:

--- a/roles/hlf/cli/orderer/tasks/main.yaml
+++ b/roles/hlf/cli/orderer/tasks/main.yaml
@@ -122,7 +122,7 @@
 - name: Fabric Service - {{ orderer.name }}
   become: yes
   docker_swarm_service:
-    restart_policy: "none"
+    restart_policy: "on-failure"
     name: "{{ orderer.name }}_cli"
     hostname: "{{ orderer.name }}_cli"
     networks:
@@ -156,5 +156,6 @@
   when: orderer.switch == "on"
 
 # Pause for 5 seconds for genesis block to be created.
-- pause:
-    seconds: 5
+- name: Pause for 5 seconds for genesis block to be created.
+  pause:
+      seconds: "5"

--- a/roles/hlf/cli/peer/tasks/main.yml
+++ b/roles/hlf/cli/peer/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: Fabric Service - {{ item.name }}
   become: yes
   docker_swarm_service:
-    restart_policy: "none"
+    restart_policy: "on-failure"
     name: "{{item.name}}_cli"
     hostname: "{{item.name}}_cli"
     networks:


### PR DESCRIPTION
**fixes issue #51 "peer2_cli" service fails to start sometimes, as it starts before peer2 service is ready**

- modified restart_policy of all "_cli" services from "none" to "on-failure".
- Now the "_cli" services will be restarted until they are successfully completed for the first time.
- Elegant way is to use "depends_on" option in docker compose which will wait for the dependent service.
- But the "depends_on" feature is not supported in ansible's community.general.docker_swarm_service
- The restart_policy: "on-failure" does the trick.