### PR TITLE
Replaced Ansible Docker Swarm's "restart_policy" flag with "restart_config"

### DIFF
--- a/roles/hlf/cli/ca/tasks/main.yaml
+++ b/roles/hlf/cli/ca/tasks/main.yaml
@@ -26,7 +26,9 @@
 - name: ENROLL Agents for Fabric Service - "{{ item.0.name }}_{{item.1.1.name}}_cli"
   become: yes
   docker_swarm_service:
-    restart_policy: "on-failure"
+    # restart_policy: "on-failure"
+    restart_config:
+      condition : "on-failure"
     name: "{{ item.0.name }}_{{item.1.1.name}}_cli"
     hostname: "{{ item.0.name }}_{{item.1.1.name}}_cli"
     networks:

--- a/roles/hlf/cli/orderer/tasks/main.yaml
+++ b/roles/hlf/cli/orderer/tasks/main.yaml
@@ -122,7 +122,9 @@
 - name: Fabric Service - {{ orderer.name }}
   become: yes
   docker_swarm_service:
-    restart_policy: "on-failure"
+    #restart_policy: "on-failure"
+    restart_config:
+      condition : "on-failure"
     name: "{{ orderer.name }}_cli"
     hostname: "{{ orderer.name }}_cli"
     networks:

--- a/roles/hlf/cli/peer/tasks/main.yml
+++ b/roles/hlf/cli/peer/tasks/main.yml
@@ -41,7 +41,9 @@
 - name: Fabric Service - {{ item.name }}
   become: yes
   docker_swarm_service:
-    restart_policy: "on-failure"
+    #restart_policy: "on-failure"
+    restart_config:
+      condition : "on-failure"
     name: "{{item.name}}_cli"
     hostname: "{{item.name}}_cli"
     networks:


### PR DESCRIPTION
**Replaced Ansible Docker Swarm's "restart_policy" flag with "restart_config"**

- Reference : https://docs.ansible.com/ansible/2.9/modules/docker_swarm_service_module.html

![Screenshot from 2021-12-21 18-30-02](https://user-images.githubusercontent.com/30879156/146973919-5124497e-f4a0-44b8-a7ef-7f972a708377.png)
