### PR TITLE
Fixes issue #70 - Permission denied when running playbook "011.initialize_host.yml" during the task "Add new apt source for GlusterFS.

### DIFF
--- a/roles/init/common_packages/tasks/main.yml
+++ b/roles/init/common_packages/tasks/main.yml
@@ -42,6 +42,7 @@
 
   # GlusterFS Repos
 - name: Add new apt source for GlusterFS
+  become: yes
   apt_repository:
     repo: ppa:gluster/glusterfs-{{ glusterd_version }}
     filename: gluster.list
@@ -49,12 +50,14 @@
   when: ansible_os_family == 'Debian'
 
 - name: Add an RPM signing key for GusterFS, uses whichever key is at the URL
+  become: yes
   rpm_key:
     key: http://download.gluster.org/pub/gluster/glusterfs/{{ glusterd_version }}/rsa.pub
     state: present
   when: ansible_os_family == 'RedHat'
 
 - name: Add new yum source for GlusterFS
+  become: yes
   yum_repository:
     name: glusterfs
     description: glusterfs YUM repo


### PR DESCRIPTION
**Fixes issue #70 - Permission denied when running playbook "011.initialize_host.yml" during the task "Add new apt source for GlusterFS.**

- **become as "root"** when executing the permission denied tasks